### PR TITLE
Heredoc did not detected

### DIFF
--- a/spec/fixtures/pass/heredoc.pp
+++ b/spec/fixtures/pass/heredoc.pp
@@ -29,12 +29,7 @@ file { 'file':
         \@mynetworks => 'MYNETS',
     );
     $policy_bank{'MYNETS'} = {
-        originating => 1,
-        final_virus_destiny => D_REJECT,
-        final_spam_destiny => D_REJECT,
-        final_bad_header_destiny => D_PASS,
-        terminate_dsn_on_notify_success => 0,
-        warnbadhsender => 1,
+        originating => 1
     };
     | FILE
   ;

--- a/spec/fixtures/pass/heredoc.pp
+++ b/spec/fixtures/pass/heredoc.pp
@@ -19,3 +19,23 @@ case fact('os.family') {
       | EOT
   }
 }
+
+file { 'file':
+  content => @(FILE),
+    $signed_header_fields{'received'} = 0;
+    $enable_dkim_verification = 1;
+    $enable_dkim_signing = 1;
+    @client_ipaddr_policy = (
+        \@mynetworks => 'MYNETS',
+    );
+    $policy_bank{'MYNETS'} = {
+        originating => 1,
+        final_virus_destiny => D_REJECT,
+        final_spam_destiny => D_REJECT,
+        final_bad_header_destiny => D_PASS,
+        terminate_dsn_on_notify_success => 0,
+        warnbadhsender => 1,
+    };
+    | FILE
+  ;
+}


### PR DESCRIPTION
Hi,

I'm currently integrate `puppet-lint-strict_indent-check` but it currently detect one heredoc syntax not correctly.

```puppet
  concat::fragment { '/etc/amavis/conf.d/50-user/dkim':
    target  => '/etc/amavis/conf.d/50-user',
    order   => '10',
    content => @(FILE),
      $signed_header_fields{'received'} = 0;
      $enable_dkim_verification = 1;
      $enable_dkim_signing = 1;
      @client_ipaddr_policy = (
          \@mynetworks => 'MYNETS',
      );
      $policy_bank{'MYNETS'} = {
          originating => 1,
          final_virus_destiny => D_REJECT,
          final_spam_destiny => D_REJECT,
          final_bad_header_destiny => D_PASS,
          terminate_dsn_on_notify_success => 0,
          warnbadhsender => 1,
      };
      | FILE
    ;
  }
```

The error I get:

```
postfix/amavis.pp:160:strict_indent:WARNING:indent should be 6 chars and is 0

  $signed_header_fields{'received'} = 0;
  ^
```

Other heredoc location are fine. I guess something detected wrong, if there is a $. I add a case here as test.