### PR TITLE
Remove SimpleCov.start as it is done by PuppetLint's spec_helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,29 +1,5 @@
 # frozen_string_literal: true
 
-begin
-  require 'simplecov'
-  require 'simplecov-console'
-  require 'codecov'
-rescue LoadError
-else
-  SimpleCov.start do
-    track_files 'lib/**/*.rb'
-
-    add_filter '/spec'
-
-    enable_coverage :branch
-
-    # do not track vendored files
-    add_filter '/vendor'
-    add_filter '/.vendor'
-  end
-
-  SimpleCov.formatters = [
-    SimpleCov::Formatter::Console,
-    SimpleCov::Formatter::Codecov,
-  ]
-end
-
 require 'puppet-lint'
 require 'rspec/collection_matchers'
 


### PR DESCRIPTION
Remove SimpleCov.start as this is done by the call to PuppetLint::Plugins.load_spec_helper later in this file.

Fixes Ruby 3.1 test - #45 