### PR TITLE
Refactor heredoc indent calculations

### DIFF
--- a/spec/fixtures/fail/heredoc_interpolated_extra.pp
+++ b/spec/fixtures/fail/heredoc_interpolated_extra.pp
@@ -1,0 +1,5 @@
+$variable = @(EOT)
+    This is a multiline
+    with a ${variable}
+    heredoc string
+   | EOT

--- a/spec/fixtures/fail/heredoc_interpolated_insuficient.pp
+++ b/spec/fixtures/fail/heredoc_interpolated_insuficient.pp
@@ -1,0 +1,5 @@
+$variable = @(EOT)
+This is a multiline
+with a ${variable}
+heredoc string
+| EOT

--- a/spec/fixtures/pass/heredocclass.pp
+++ b/spec/fixtures/pass/heredocclass.pp
@@ -1,0 +1,31 @@
+# Tests for heredocs within class
+class 'heredocclass' {
+  file { '/heredoc/file/resource/without/comma':
+    content => @(HERE)
+      This is a here doc
+      with two lines
+      | HERE
+  }
+
+  file { '/heredoc/file/resource/with/comma':
+    content => @(HERE),
+      This is a here doc
+      with two lines
+      | HERE
+  }
+
+  file { '/heredoc/in/function/in/file/resource':
+    content => inlineepp(@(HERE)),
+      This is a here doc
+      with two lines
+      | HERE
+  }
+
+  $variable_with_interpolation = @("EOT")
+    Another example
+    ${variable}
+    with
+    ${variable}
+    with interpolation
+    | EOT
+}

--- a/spec/puppet-lint/plugins/check_strict_indent_spec.rb
+++ b/spec/puppet-lint/plugins/check_strict_indent_spec.rb
@@ -163,4 +163,126 @@ describe 'strict_indent' do
       expect(manifest).to eq fixed
     end
   end
+
+  context 'misaligned heredocs' do
+    before do
+      PuppetLint.configuration.fix = true
+    end
+
+    after do
+      PuppetLint.configuration.fix = false
+    end
+
+    let(:code) do
+      <<~EOF
+        $over_indented = @(HERE)
+            This is a heredoc
+            that has been
+
+            indented 4 spaces
+               and has some
+             internal indenting
+            | HERE
+
+        $under_indented = @(HERE)
+        This is a heredoc
+
+        that has no
+        indent
+          and has some
+         internal indenting
+        | HERE
+
+        $over_indented_interpolated = @("HERE")
+            This is a heredoc
+            with a ${variable}
+            that has been
+
+            indented 4 spaces
+               and has some
+             internal indenting
+            and ${another} variable
+            | HERE
+
+        $under_indented_interpolated = @("HERE")
+         This is a heredoc
+         with a ${variable} with trailing text
+         that has been
+
+         indented 1 space
+             and has some
+               internal indenting
+         and ${another} variable
+         | HERE
+      EOF
+    end
+
+    let(:fixed) do
+      <<~EOF
+        $over_indented = @(HERE)
+          This is a heredoc
+          that has been
+
+          indented 4 spaces
+             and has some
+           internal indenting
+          | HERE
+
+        $under_indented = @(HERE)
+          This is a heredoc
+
+          that has no
+          indent
+            and has some
+           internal indenting
+          | HERE
+
+        $over_indented_interpolated = @("HERE")
+          This is a heredoc
+          with a ${variable}
+          that has been
+
+          indented 4 spaces
+             and has some
+           internal indenting
+          and ${another} variable
+          | HERE
+
+        $under_indented_interpolated = @("HERE")
+          This is a heredoc
+          with a ${variable} with trailing text
+          that has been
+
+          indented 1 space
+              and has some
+                internal indenting
+          and ${another} variable
+          | HERE
+      EOF
+    end
+
+    it 'detects four problems' do
+      expect(problems).to have(4).problem
+    end
+
+    it 'fixes the first problem' do
+      expect(problems).to contain_fixed('indent should be 2 chars and is 4').on_line(2).in_column(1)
+    end
+
+    it 'fixes the second problem' do
+      expect(problems).to contain_fixed('indent should be 2 chars and is 0').on_line(11).in_column(1)
+    end
+
+    it 'fixes the third problem' do
+      expect(problems).to contain_fixed('indent should be 2 chars and is 4').on_line(20).in_column(1)
+    end
+
+    it 'fixes the forth problem' do
+      expect(problems).to contain_fixed('indent should be 2 chars and is 1').on_line(31).in_column(1)
+    end
+
+    it 'moves the heredoc' do
+      expect(manifest).to eq fixed
+    end
+  end
 end


### PR DESCRIPTION
The existing implementation only appears to calculate the indent correctly when `HEREDOC_OPEN` is the final token of the preceding line.

I've removed the open/close logic for `HEREDOC` tokens. This doesn't look to be necessary as a `HEREDOC_OPEN` is always on the preceding line to either a `HEREDOC` or `HEREDOC_POST` token which means `open_groups` never gets incremented.

The existing logic that increments `temp_indent` when the previous line contains a `HEREDOC_OPEN` is retained as this calculates the correct indent for the line.

The `actual` indent calculation is rewritten so this is extracted from the `HEREDOC` or `HEREDOC_POST` token in the current line. This is necessary as there are no `INDENT` token on a heredoc line.

I've added an number of test cases which weren't working correct with the original implementation and these all pass with the new logic.

This should fix most if not all of the issues in the comments on #20 