### PR TITLE
Match the indent for a single semicolon with the Puppet documentation

### DIFF
--- a/lib/puppet-lint/plugins/check_strict_indent.rb
+++ b/lib/puppet-lint/plugins/check_strict_indent.rb
@@ -120,6 +120,13 @@ PuppetLint.new_check(:strict_indent) do
         next_token = next_token.next_token
       end
 
+      # For a lone semicolon within a block decrement immediately. Use temp_indent because
+      # indent will be decremented in the next line by the prev_token logic above.
+      temp_indent -= 1 if !colon_indent.nil? and
+                          token.next_token.type == :INDENT and
+                          token.next_token.next_token.type == :SEMIC and
+                          token.next_token.next_token.next_token.type == :NEWLINE
+
       # obviously we have a problem
       if indent < 0
         notify :error, {

--- a/spec/fixtures/fail/semicolon_long.pp
+++ b/spec/fixtures/fail/semicolon_long.pp
@@ -1,0 +1,15 @@
+file {
+  default:
+    ensure => file,
+    owner  => 'root',
+    group  => 'wheel',
+    mode   => '0600',
+    ;
+  ['ssh_host_dsa_key', 'ssh_host_key', 'ssh_host_rsa_key']:
+    # use all defaults
+  ;
+  ['ssh_config', 'ssh_host_dsa_key.pub', 'ssh_host_key.pub', 'ssh_host_rsa_key.pub', 'sshd_config']:
+    # override mode
+    mode => '0644',
+  ;
+}

--- a/spec/fixtures/fail/semicolon_short.pp
+++ b/spec/fixtures/fail/semicolon_short.pp
@@ -1,0 +1,15 @@
+file {
+  default:
+    ensure => file,
+    owner  => 'root',
+    group  => 'wheel',
+    mode   => '0600',
+  ;
+  ['ssh_host_dsa_key', 'ssh_host_key', 'ssh_host_rsa_key']:
+    # use all defaults
+;
+  ['ssh_config', 'ssh_host_dsa_key.pub', 'ssh_host_key.pub', 'ssh_host_rsa_key.pub', 'sshd_config']:
+    # override mode
+    mode => '0644',
+  ;
+}

--- a/spec/fixtures/pass/semicolon.pp
+++ b/spec/fixtures/pass/semicolon.pp
@@ -1,0 +1,15 @@
+file {
+  default:
+    ensure => file,
+    owner  => 'root',
+    group  => 'wheel',
+    mode   => '0600',
+  ;
+  ['ssh_host_dsa_key', 'ssh_host_key', 'ssh_host_rsa_key']:
+    # use all defaults
+  ;
+  ['ssh_config', 'ssh_host_dsa_key.pub', 'ssh_host_key.pub', 'ssh_host_rsa_key.pub', 'sshd_config']:
+    # override mode
+    mode => '0644',
+  ;
+}


### PR DESCRIPTION
Change the handling of indent on the semicolon separator in resource statements so it match the Puppet documentation example:
https://www.puppet.com/docs/puppet/7/lang_resources#resource-declaration-default-attributes

Fixes #19 

Example from Puppet docs:
```
file {
  default:
    ensure => file,
    owner  => "root",
    group  => "wheel",
    mode   => "0600",
  ;
  ['ssh_host_dsa_key', 'ssh_host_key', 'ssh_host_rsa_key']:
    # use all defaults
  ;
  ['ssh_config', 'ssh_host_dsa_key.pub', 'ssh_host_key.pub', 'ssh_host_rsa_key.pub', 'sshd_config']:
    # override mode
    mode => "0644",
  ;
}
```

Currently the plugin expects this to be indented like this:
```
file {
  default:
    ensure => file,
    owner  => "root",
    group  => "wheel",
    mode   => "0600",
    ;
  ['ssh_host_dsa_key', 'ssh_host_key', 'ssh_host_rsa_key']:
    # use all defaults
    ;
  ['ssh_config', 'ssh_host_dsa_key.pub', 'ssh_host_key.pub', 'ssh_host_rsa_key.pub', 'sshd_config']:
    # override mode
    mode => "0644",
    ;
}
```